### PR TITLE
fix withdraw min funds requirement

### DIFF
--- a/project.md
+++ b/project.md
@@ -92,7 +92,7 @@ Regras:
 
 * A conta deve existir
 * O assetId permitido é BTC ou USD
-* A quantidade deve ser maior ou igual ao saldo
+* A quantidade deve ser menor ou igual ao saldo
 
 ***
 


### PR DESCRIPTION
The requirement states that for a withdraw, the withdrawn value should be equal or **bigger** than the customer funds, while, in fact, the user can not withdraw more than what it has: the withdraw should be **less than** or equal to the funds.